### PR TITLE
Feature/c/shydentity 2

### DIFF
--- a/did.go
+++ b/did.go
@@ -28,6 +28,8 @@ const (
 	DIDMethodIden3 DIDMethod = "iden3"
 	// DIDMethodPolygonID DID method-name
 	DIDMethodPolygonID DIDMethod = "polygonid"
+	// DIDMethodShib
+	DIDMethodShib DIDMethod = "shib"
 )
 
 // Blockchain id of the network "eth", "polygon", etc.
@@ -38,6 +40,8 @@ const (
 	Ethereum Blockchain = "eth"
 	// Polygon is polygon blockchain network
 	Polygon Blockchain = "polygon"
+	// Shibarium is Shibarium blockchain network
+	Shibarium Blockchain = "shibarium"
 	// UnknownChain is used when it's not possible to retrieve blockchain type from identifier
 	UnknownChain Blockchain = "unknown"
 	// NoChain should be used for readonly identity to build readonly flag
@@ -55,6 +59,10 @@ const (
 
 	// Goerli is ethereum goerli test network
 	Goerli NetworkID = "goerli" // goerli
+
+	// Test is test network
+	Test NetworkID = "test"
+
 	// UnknownNetwork is used when it's not possible to retrieve network from identifier
 	UnknownNetwork NetworkID = "unknown"
 
@@ -66,6 +74,7 @@ const (
 var DIDMethodByte = map[DIDMethod]byte{
 	DIDMethodIden3:     0b00000001,
 	DIDMethodPolygonID: 0b00000010,
+	DIDMethodShib:      0b00000011,
 }
 
 // DIDNetworkFlag is a structure to represent DID blockchain and network id
@@ -90,6 +99,10 @@ var DIDMethodNetwork = map[DIDMethod]map[DIDNetworkFlag]byte{
 
 		{Blockchain: Polygon, NetworkID: Main}:   0b00010000 | 0b00000001,
 		{Blockchain: Polygon, NetworkID: Mumbai}: 0b00010000 | 0b00000010,
+	},
+	DIDMethodShib: {
+		{Blockchain: Shibarium, NetworkID: Main}: 0b01000000 | 0b00000001,
+		{Blockchain: Shibarium, NetworkID: Test}: 0b01000000 | 0b00000010,
 	},
 }
 

--- a/did.go
+++ b/did.go
@@ -60,8 +60,8 @@ const (
 	// Goerli is ethereum goerli test network
 	Goerli NetworkID = "goerli" // goerli
 
-	// Test is test network
-	Test NetworkID = "test"
+	// puppynet is shib test network
+	PuppyNet NetworkID = "puppynet"
 
 	// UnknownNetwork is used when it's not possible to retrieve network from identifier
 	UnknownNetwork NetworkID = "unknown"
@@ -103,8 +103,8 @@ var DIDMethodNetwork = map[DIDMethod]map[DIDNetworkFlag]byte{
 	DIDMethodShib: {
 		{Blockchain: NoChain, NetworkID: NoNetwork}: 0b00000000,
 
-		{Blockchain: Shibarium, NetworkID: Main}: 0b01000000 | 0b00000001,
-		{Blockchain: Shibarium, NetworkID: Test}: 0b01000000 | 0b00000010,
+		{Blockchain: Shibarium, NetworkID: Main}:     0b01000000 | 0b00000001,
+		{Blockchain: Shibarium, NetworkID: PuppyNet}: 0b01000000 | 0b00000010,
 	},
 }
 

--- a/did.go
+++ b/did.go
@@ -101,6 +101,8 @@ var DIDMethodNetwork = map[DIDMethod]map[DIDNetworkFlag]byte{
 		{Blockchain: Polygon, NetworkID: Mumbai}: 0b00010000 | 0b00000010,
 	},
 	DIDMethodShib: {
+		{Blockchain: NoChain, NetworkID: NoNetwork}: 0b00000000,
+
 		{Blockchain: Shibarium, NetworkID: Main}: 0b01000000 | 0b00000001,
 		{Blockchain: Shibarium, NetworkID: Test}: 0b01000000 | 0b00000010,
 	},

--- a/did_test.go
+++ b/did_test.go
@@ -35,9 +35,26 @@ func TestParseDID(t *testing.T) {
 	require.Equal(t, [2]byte{DIDMethodByte[DIDMethodIden3], 0b0}, did.ID.Type())
 }
 
-func TextCreateNewShibDID(t *testing.T) {
+func TestCreateNewShibDID(t *testing.T) {
 
 	typ0, err := BuildDIDType(DIDMethodShib, Shibarium, Main)
+	require.NoError(t, err)
+
+	genesisState := big.NewInt(1)
+	did, err := DIDGenesisFromIdenState(typ0, genesisState)
+	require.NoError(t, err)
+
+	didStr := did.String()
+	did2, err := ParseDID(didStr)
+	require.NoError(t, err)
+
+	require.Equal(t, did.Method, did2.Method)
+	require.Equal(t, did.ID, did2.ID)
+}
+
+func TestCreateNewShibReadonlyDID(t *testing.T) {
+
+	typ0, err := BuildDIDType(DIDMethodShib, NoChain, NoNetwork)
 	require.NoError(t, err)
 
 	genesisState := big.NewInt(1)

--- a/did_test.go
+++ b/did_test.go
@@ -62,6 +62,9 @@ func TestCreateNewShibReadonlyDID(t *testing.T) {
 	require.NoError(t, err)
 
 	didStr := did.String()
+
+	require.Equal(t, didStr, "did:shib:3etR8HpjUyg29h5ssFaTghiBezcpmhidcZ6Z5WuNr3")
+
 	did2, err := ParseDID(didStr)
 	require.NoError(t, err)
 

--- a/did_test.go
+++ b/did_test.go
@@ -35,6 +35,41 @@ func TestParseDID(t *testing.T) {
 	require.Equal(t, [2]byte{DIDMethodByte[DIDMethodIden3], 0b0}, did.ID.Type())
 }
 
+func TextCreateNewShibDID(t *testing.T) {
+
+	typ0, err := BuildDIDType(DIDMethodShib, Shibarium, Main)
+	require.NoError(t, err)
+
+	genesisState := big.NewInt(1)
+	did, err := DIDGenesisFromIdenState(typ0, genesisState)
+	require.NoError(t, err)
+
+	didStr := did.String()
+	did2, err := ParseDID(didStr)
+	require.NoError(t, err)
+
+	require.Equal(t, did.Method, did2.Method)
+	require.Equal(t, did.ID, did2.ID)
+}
+
+func TestParseShibDID(t *testing.T) {
+
+	didStr := "did:shib:shibarium:main:3suph5aVnT3uDycoQqtYjm5eJx2295k3L5XeHXd8Kq"
+
+	did, err := ParseDID(didStr)
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	require.Equal(t, "3suph5aVnT3uDycoQqtYjm5eJx2295k3L5XeHXd8Kq", did.ID.String())
+	method := did.Method
+	require.Equal(t, DIDMethodShib, method)
+	blockchain := did.Blockchain
+	require.Equal(t, Shibarium, blockchain)
+	networkID := did.NetworkID
+	require.Equal(t, Main, networkID)
+
+}
+
 func TestDID_MarshalJSON(t *testing.T) {
 	id, err := IDFromString("wyFiV4w71QgWPn6bYLsZoysFay66gKtVa9kfu6yMZ")
 	require.NoError(t, err)

--- a/did_test.go
+++ b/did_test.go
@@ -37,14 +37,19 @@ func TestParseDID(t *testing.T) {
 
 func TestCreateNewShibDID(t *testing.T) {
 
-	typ0, err := BuildDIDType(DIDMethodShib, Shibarium, Main)
+	p, _ := BuildDIDType(DIDMethodShib, Shibarium, PuppyNet)
+	require.Equal(t, p[0], uint8(0x03))
+	require.Equal(t, p[1], uint8(0x42))
+
+	typ0, err := BuildDIDType(DIDMethodShib, Shibarium, PuppyNet)
 	require.NoError(t, err)
 
-	genesisState := big.NewInt(1)
+	genesisState, _ := new(big.Int).SetString("0xC46A8845844a1ec44d18C48a7e3a6f919893C728", 0)
 	did, err := DIDGenesisFromIdenState(typ0, genesisState)
 	require.NoError(t, err)
 
 	didStr := did.String()
+	require.Equal(t, didStr, "did:shib:shibarium:puppynet:3tCVcahkPK58AGXwZuSgFsM1dmCGezVuwsciBFVYiZ")
 	did2, err := ParseDID(didStr)
 	require.NoError(t, err)
 


### PR DESCRIPTION
First modifications to add Shibarium support to polygonID

## Description
Added a new `did:shib` method, new `Shibarium` chain and 2 networks (`Main` and `Puppynet`).
Added to the existing tests for parsing of DIDs.

This PR will merge into `add-shibarium-support` branch and not master, so that we can easily submit our changes to the upstream @0xPolygonID

## Related Issue
[https://shibaone.atlassian.net/browse/SHYDENTITY-2?atlOrigin=eyJpIjoiZjJlOWY2YzkwYmNkNGI3ZGI0NGVjMzg2Yzg0N2MwZjIiLCJwIjoiaiJ9](https://shibaone.atlassian.net/browse/SHYDENTITY-2?atlOrigin=eyJpIjoiZjJlOWY2YzkwYmNkNGI3ZGI0NGVjMzg2Yzg0N2MwZjIiLCJwIjoiaiJ9)
*edited to link to correct issue*

## Motivation and Context
This modification adds support for the Shibarium chain.

## How Has This Been Tested?
Automated tests, integration into resolver and issuer node
